### PR TITLE
Improve minimalist UI

### DIFF
--- a/src/components/home/CategoryGrid.tsx
+++ b/src/components/home/CategoryGrid.tsx
@@ -7,11 +7,15 @@ const categories = [
 
 export default function CategoryGrid() {
   return (
-    <section className="grid grid-cols-2 md:grid-cols-4 gap-4 py-12">
+    <section className="grid grid-cols-2 gap-6 py-16 md:grid-cols-4">
       {categories.map(cat => (
-        <div key={cat.title} className="text-center">
-          <img src={cat.img} alt={cat.title} className="rounded-lg mb-2 h-32 w-full object-cover" />
-          <h3 className="font-semibold">{cat.title}</h3>
+        <div key={cat.title} className="text-center space-y-2">
+          <img
+            src={cat.img}
+            alt={cat.title}
+            className="h-40 w-full rounded-lg object-cover"
+          />
+          <h3 className="text-lg font-medium text-primary">{cat.title}</h3>
         </div>
       ))}
     </section>

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,8 +1,19 @@
 export default function Hero() {
   return (
-    <section className="text-center py-20 bg-[url('https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=1350&q=80')] bg-cover bg-center rounded-lg text-white">
-      <h1 className="text-5xl font-bold mb-4">Shine Bright</h1>
-      <p className="text-xl">Discover exquisite gold jewelry crafted to perfection.</p>
+    <section
+      className="relative isolate overflow-hidden rounded-lg bg-neutral-200 py-24 text-center"
+    >
+      <img
+        src="https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=1600&q=80"
+        alt="Gold jewelry"
+        className="absolute inset-0 -z-10 h-full w-full object-cover opacity-60"
+      />
+      <h1 className="mb-4 text-6xl font-semibold tracking-tight text-primary">
+        Timeless Elegance
+      </h1>
+      <p className="text-lg text-foreground/80">
+        Discover exquisite gold jewelry crafted to perfection.
+      </p>
     </section>
   );
 }

--- a/src/components/home/ProductCarousel.tsx
+++ b/src/components/home/ProductCarousel.tsx
@@ -8,12 +8,12 @@ const items = [
 
 export default function ProductCarousel() {
   return (
-    <section className="py-12">
+    <section className="py-16">
       <Carousel>
         <CarouselContent>
           {items.map((src, idx) => (
             <CarouselItem key={idx} className="basis-full">
-              <img src={src} className="w-full h-64 object-cover rounded-lg" />
+              <img src={src} className="h-72 w-full rounded-lg object-cover" />
             </CarouselItem>
           ))}
         </CarouselContent>

--- a/src/components/home/PromoBanner.tsx
+++ b/src/components/home/PromoBanner.tsx
@@ -1,8 +1,8 @@
 export default function PromoBanner() {
   return (
-    <div className="bg-yellow-50 border rounded-lg p-6 text-center">
-      <h2 className="text-2xl font-semibold mb-2">Winter Sale</h2>
-      <p>Up to 30% off on selected pieces.</p>
+    <div className="rounded-lg border bg-white p-8 text-center">
+      <h2 className="mb-2 text-3xl font-medium tracking-tight">Winter Sale</h2>
+      <p className="text-foreground/80">Up to 30% off on selected pieces.</p>
     </div>
   );
 }

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -10,13 +10,13 @@ export interface Product {
 
 export default function ProductCard({ product }: { product: Product }) {
   return (
-    <div className="border rounded-lg p-4 text-center flex flex-col gap-2">
+    <div className="flex flex-col gap-3 rounded-lg border p-6 text-center">
       <img
         src={product.img}
         alt={product.name}
-        className="h-40 w-full object-cover rounded"
+        className="h-48 w-full rounded object-cover"
       />
-      <h3 className="font-semibold">{product.name}</h3>
+      <h3 className="text-lg font-medium">{product.name}</h3>
       <p className="text-sm text-muted-foreground">{product.price}</p>
       <Button variant="secondary" className="mt-auto">
         Add to Cart

--- a/src/index.css
+++ b/src/index.css
@@ -2,36 +2,16 @@
 
 @layer base {
   :root {
-    @apply font-sans;
+    font-family: "Inter", sans-serif;
   }
 
   body {
-    @apply grid place-items-center min-w-[320px] min-h-screen relative m-0 bg-background text-foreground;
+    @apply min-w-[320px] min-h-screen relative m-0 bg-background text-foreground;
   }
 }
 
-/* cool Bun background animation 😎 */
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  opacity: 0.05;
-  background: url("./logo.svg");
-  background-size: 256px;
-  transform: rotate(-12deg) scale(1.35);
-  animation: slide 30s linear infinite;
-  pointer-events: none;
-}
+/* Remove busy background for a cleaner look */
 
-@keyframes slide {
-  from {
-    background-position: 0 0;
-  }
-  to {
-    background-position: 256px 224px;
-  }
-}
 
 @keyframes spin {
   from {

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="./logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Bun + React</title>
     <script type="module" src="./frontend.tsx" async></script>
   </head>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,16 +5,16 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(240 10% 3.9%);
+  --background: hsl(0 0% 97%);
+  --foreground: hsl(0 0% 20%);
   --card: hsl(0 0% 100%);
-  --card-foreground: hsl(240 10% 3.9%);
+  --card-foreground: hsl(0 0% 15%);
   --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(240 10% 3.9%);
-  --primary: hsl(240 5.9% 10%);
+  --popover-foreground: hsl(0 0% 20%);
+  --primary: hsl(0 0% 10%);
   --primary-foreground: hsl(0 0% 98%);
-  --secondary: hsl(240 4.8% 95.9%);
-  --secondary-foreground: hsl(240 5.9% 10%);
+  --secondary: hsl(0 0% 92%);
+  --secondary-foreground: hsl(0 0% 20%);
   --muted: hsl(240 4.8% 95.9%);
   --muted-foreground: hsl(240 3.8% 46.1%);
   --accent: hsl(240 4.8% 95.9%);


### PR DESCRIPTION
## Summary
- pull Inter font from Google Fonts
- simplify body styling and remove background graphic
- switch to neutral palette in Tailwind variables
- refresh Hero, category grid, carousel, promo banner and product card styles

## Testing
- `bun run build.ts`

------
https://chatgpt.com/codex/tasks/task_e_684bf7ffa924832bb6bbe82acebfd653