### PR TITLE
Enhance responsive UI

### DIFF
--- a/src/components/home/CategoryGrid.tsx
+++ b/src/components/home/CategoryGrid.tsx
@@ -10,7 +10,14 @@ export default function CategoryGrid() {
     <section className="grid grid-cols-2 md:grid-cols-4 gap-4 py-12">
       {categories.map(cat => (
         <div key={cat.title} className="text-center">
-          <img src={cat.img} alt={cat.title} className="rounded-lg mb-2 h-32 w-full object-cover" />
+          <img
+            src={cat.img}
+            srcSet={`${cat.img} 1x, ${cat.img.replace('w=400', 'w=800')} 2x`}
+            sizes="(min-width: 768px) 200px, 50vw"
+            loading="lazy"
+            alt={cat.title}
+            className="rounded-lg mb-2 h-32 w-full object-cover"
+          />
           <h3 className="font-semibold">{cat.title}</h3>
         </div>
       ))}

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,8 +1,8 @@
 export default function Hero() {
   return (
-    <section className="text-center py-20 bg-[url('https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=1350&q=80')] bg-cover bg-center rounded-lg text-white">
-      <h1 className="text-5xl font-bold mb-4">Shine Bright</h1>
-      <p className="text-xl">Discover exquisite gold jewelry crafted to perfection.</p>
+    <section className="text-center py-16 md:py-20 bg-[url('https://images.unsplash.com/photo-1522312346375-d1a52e2b99b3?auto=format&fit=crop&w=1350&q=80')] bg-cover bg-center rounded-lg text-white">
+      <h1 className="text-4xl md:text-5xl font-bold mb-4">Shine Bright</h1>
+      <p className="text-lg md:text-xl">Discover exquisite gold jewelry crafted to perfection.</p>
     </section>
   );
 }

--- a/src/components/home/ProductCarousel.tsx
+++ b/src/components/home/ProductCarousel.tsx
@@ -13,7 +13,13 @@ export default function ProductCarousel() {
         <CarouselContent>
           {items.map((src, idx) => (
             <CarouselItem key={idx} className="basis-full">
-              <img src={src} className="w-full h-64 object-cover rounded-lg" />
+              <img
+                src={src}
+                srcSet={`${src} 1x, ${src.replace('w=800', 'w=1600')} 2x`}
+                sizes="(min-width: 768px) 768px, 100vw"
+                loading="lazy"
+                className="w-full h-64 object-cover rounded-lg"
+              />
             </CarouselItem>
           ))}
         </CarouselContent>

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -13,6 +13,9 @@ export default function ProductCard({ product }: { product: Product }) {
     <div className="border rounded-lg p-4 text-center flex flex-col gap-2">
       <img
         src={product.img}
+        srcSet={`${product.img} 1x, ${product.img.replace('w=800', 'w=1600')} 2x`}
+        sizes="(min-width: 768px) 25vw, 50vw"
+        loading="lazy"
         alt={product.name}
         className="h-40 w-full object-cover rounded"
       />

--- a/src/components/product/ProductCardList.tsx
+++ b/src/components/product/ProductCardList.tsx
@@ -2,7 +2,7 @@ import ProductCard, { Product } from "./ProductCard";
 
 export default function ProductCardList({ products }: { products: Product[] }) {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
       {products.map(p => (
         <ProductCard key={p.id} product={p} />
       ))}

--- a/src/components/product/ProductDetail.tsx
+++ b/src/components/product/ProductDetail.tsx
@@ -24,11 +24,24 @@ export default function ProductDetail() {
   return (
     <div className="flex flex-col md:flex-row gap-6">
       <div className="md:w-1/2">
-        <img src={selected} alt="Product" className="rounded-lg w-full" />
+        <img
+          src={selected}
+          srcSet={`${selected} 1x, ${selected.replace('w=800', 'w=1600')} 2x`}
+          sizes="(min-width: 768px) 50vw, 100vw"
+          loading="lazy"
+          alt="Product"
+          className="rounded-lg w-full object-cover"
+        />
         <div className="flex gap-2 mt-4">
           {images.map(img => (
-            <button key={img} onClick={() => setSelected(img)} className={`border rounded-md overflow-hidden ${selected === img ? 'border-ring' : ''}`}> 
-              <img src={img} className="h-16 w-16 object-cover" />
+            <button key={img} onClick={() => setSelected(img)} className={`border rounded-md overflow-hidden ${selected === img ? 'border-ring' : ''}`}>
+              <img
+                src={img}
+                srcSet={`${img} 1x, ${img.replace('w=800', 'w=1600')} 2x`}
+                sizes="64px"
+                loading="lazy"
+                className="h-16 w-16 object-cover"
+              />
             </button>
           ))}
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   }
 
   body {
-    @apply grid place-items-center min-w-[320px] min-h-screen relative m-0 bg-background text-foreground;
+    @apply grid place-items-center min-w-[320px] min-h-screen relative m-0 bg-background text-foreground leading-relaxed;
   }
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -75,6 +75,43 @@
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: hsl(240 10% 3.9%);
+    --foreground: hsl(0 0% 98%);
+    --card: hsl(240 10% 3.9%);
+    --card-foreground: hsl(0 0% 98%);
+    --popover: hsl(240 10% 3.9%);
+    --popover-foreground: hsl(0 0% 98%);
+    --primary: hsl(0 0% 98%);
+    --primary-foreground: hsl(240 5.9% 10%);
+    --secondary: hsl(240 3.7% 15.9%);
+    --secondary-foreground: hsl(0 0% 98%);
+    --muted: hsl(240 3.7% 15.9%);
+    --muted-foreground: hsl(240 5% 64.9%);
+    --accent: hsl(240 3.7% 15.9%);
+    --accent-foreground: hsl(0 0% 98%);
+    --destructive: hsl(0 62.8% 30.6%);
+    --destructive-foreground: hsl(0 0% 98%);
+    --border: hsl(240 3.7% 15.9%);
+    --input: hsl(240 3.7% 15.9%);
+    --ring: hsl(240 4.9% 83.9%);
+    --chart-1: hsl(220 70% 50%);
+    --chart-2: hsl(160 60% 45%);
+    --chart-3: hsl(30 80% 55%);
+    --chart-4: hsl(280 65% 60%);
+    --chart-5: hsl(340 75% 55%);
+    --sidebar-background: hsl(240 5.9% 10%);
+    --sidebar-foreground: hsl(240 4.8% 95.9%);
+    --sidebar-primary: hsl(224.3 76.3% 48%);
+    --sidebar-primary-foreground: hsl(0 0% 100%);
+    --sidebar-accent: hsl(240 3.7% 15.9%);
+    --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+    --sidebar-border: hsl(240 3.7% 15.9%);
+    --sidebar-ring: hsl(217.2 91.2% 59.8%);
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);


### PR DESCRIPTION
## Summary
- make dark theme automatically follow `prefers-color-scheme`
- use lazy loaded responsive images across product components
- tweak hero styling and product grid layout for small screens
- improve base typography for readability

## Testing
- `bun run build.ts`

------
https://chatgpt.com/codex/tasks/task_e_684bf8618930832ba068638b2cb991f4